### PR TITLE
forward `how` callback to twemoji parse

### DIFF
--- a/vendor/assets/javascripts/twemoji_rails.js
+++ b/vendor/assets/javascripts/twemoji_rails.js
@@ -2,8 +2,8 @@
 (function(){
   twemoji_rails = {
 
-    parse: function(unicode) {
-      return twemoji.parse(unicode.replace(/:(\w+):/g, this.replacer));
+    parse: function(unicode, how) {
+      return twemoji.parse(unicode.replace(/:(\w+):/g, this.replacer), how);
     },
 
     replacer: function(match, shortname, offset, string) {


### PR DESCRIPTION
This PR adds a second parameter to `twemoji_rails.parse` that is forwarded to `twemoji.parse`.

`twemoji.parse` now accepts a [`how`](https://github.com/twitter/twemoji/blob/gh-pages/twemoji.js#L541) parameter that allows us to pass callbacks, which is useful for  [exclusions](https://github.com/twitter/twemoji#exclude-characters).